### PR TITLE
Expression always True fault

### DIFF
--- a/src/apps/NotificationHub.Maui/Platforms/Android/ViewModels/MainPageViewModel.cs
+++ b/src/apps/NotificationHub.Maui/Platforms/Android/ViewModels/MainPageViewModel.cs
@@ -42,7 +42,7 @@ namespace NotificationHub.Maui.ViewModels
 
         private async Task<string> RegisterDeviceInstallationAsync()
         {
-            var tagList = Tags?.Split(",").Select(x => x.Trim()).ToArray() ?? new string[0];
+            var tagList = Tags?.Split(",").Select(x => x.Trim()).ToArray() ?? Array.Empty<string>();
 
             var installation = await _deviceInstallationService.GenerateDeviceInstallationAsync(tagList);
             var outcome = await _deviceRegistrationService.UpsertDeviceInstallationAsync(installation);

--- a/src/libraries/NotificationHub.Core/Services/NotificationHubService.cs
+++ b/src/libraries/NotificationHub.Core/Services/NotificationHubService.cs
@@ -16,7 +16,7 @@ public class NotificationHubService
     public async Task<IList<NotificationOutcome>> SendNotificationAsync(NotificationPlatform platform, string payload, IList<string> tags, string tagExpressions, CancellationToken cancellationToken)
     {
         bool hasTags = tags?.Count > 0 == true;
-        bool hasExpression = string.IsNullOrEmpty(tagExpressions);
+        bool hasExpression = !string.IsNullOrEmpty(tagExpressions);
         bool broadcastToAll = !hasTags && !hasExpression;
 
         List<NotificationOutcome> outcome = new();


### PR DESCRIPTION
This commit fixes an issue where notifications were being sent to all users when a specific Tag was specified. The issue was evaluation of the tag expression.  A mistake in the code was evaluating the value of the tag expression every time, instead of only when a value is present.