### PR TITLE
Platform enforcement for payload

### DIFF
--- a/src/apps/NotificationHub.MessagingFunctions/Functions/SendNotification.cs
+++ b/src/apps/NotificationHub.MessagingFunctions/Functions/SendNotification.cs
@@ -53,7 +53,7 @@ namespace NotificationHub.MessagingFunctions.Functions
                     return await request.CreateErrorResponseAsync(message);
                 }
 
-                var notificationPayload = CreateRawPayload(notification);
+                var notificationPayload = CreateRawPayload(platform, notification.Title, notification.Body);
                 var outcome = await _hubService.SendNotificationAsync(platform
                                                                     , notificationPayload
                                                                     , notification.Tags
@@ -73,20 +73,17 @@ namespace NotificationHub.MessagingFunctions.Functions
         }
 
 
-        private string CreateRawPayload(NotificationRequest notification)
+        private string CreateRawPayload(NotificationPlatform platform, string title, string body)
         {
             _payloadBuilder
-                .AddTitle(notification.Title)
-                .AddBody(notification.Body);
+                .AddTitle(title)
+                .AddBody(body);
 
-            switch (notification.Platform)
+            switch (platform)
             {
-                case "fcm":
-                    return _payloadBuilder.BuildAndroidPayload();
-                case "aps":
-                    return _payloadBuilder.BuildApplePayload();
+                case NotificationPlatform.Fcm:
                 default:
-                    throw new Exception("Invalid platform");
+                    return _payloadBuilder.BuildAndroidPayload();
             }
         }
     }


### PR DESCRIPTION
This commit enforces support for FCM only. Prior code evaluated APNS, however, not all support is there for it. Thus, we've removed references to it and now default to pushing as if it's an FCM notification